### PR TITLE
Fix LoRA hyperparameter and prompt bugs in the decoder-only shadow trainers

### DIFF
--- a/summarization/imdb_code/create_model_features_llama3-1_lora.py
+++ b/summarization/imdb_code/create_model_features_llama3-1_lora.py
@@ -111,7 +111,7 @@ class LlamaLoraTextGenerator:
 
     @torch.no_grad()
     def generate_text(self, text: str, max_new_tokens: int = 128) -> str:
-        prompt = f"Text: {text} Summary:"
+        prompt = f"Text: {text}\nSummary:"
         max_prompt_len = max(1, self.max_ctx - max_new_tokens)
 
         enc = self.tokenizer(

--- a/summarization/imdb_code/create_model_features_qwen2-5_lora.py
+++ b/summarization/imdb_code/create_model_features_qwen2-5_lora.py
@@ -111,7 +111,7 @@ class QwenLoraTextGenerator:
 
     @torch.no_grad()
     def generate_text(self, text: str, max_new_tokens: int = 128) -> str:
-        prompt = f"Text: {text} Summary:"
+        prompt = f"Text: {text}\nSummary:"
         max_prompt_len = max(1, self.max_ctx - max_new_tokens)
 
         enc = self.tokenizer(

--- a/summarization/imdb_code/simple_create_model_features_phi_lora.py
+++ b/summarization/imdb_code/simple_create_model_features_phi_lora.py
@@ -111,7 +111,7 @@ class PhiLoraTextGenerator:
 
     @torch.no_grad()
     def generate_text(self, text: str, max_new_tokens: int = 128) -> str:
-        prompt = f"Text: {text} Summary:"
+        prompt = f"Text: {text}\nSummary:"
         max_prompt_len = max(1, self.max_ctx - max_new_tokens)
 
         enc = self.tokenizer(

--- a/summarization/imdb_code/simple_shadow_models_phi_lora.py
+++ b/summarization/imdb_code/simple_shadow_models_phi_lora.py
@@ -186,6 +186,14 @@ def apply_yaml_config(args: argparse.Namespace) -> argparse.Namespace:
     args.max_target_length = int(config["data"].get("max_target_length", 128))
     args.num_train_epochs = float(config["training"]["num_train_epochs"])
     args.learning_rate = float(config["training"]["learning_rate"])
+    # LoRA hyperparameters are three of the labels the attack classifier predicts, so
+    # they must come from the config -- hardcoding them made every config for this
+    # family train identically apart from learning rate. Fall back to the CLI defaults
+    # when the key is absent, since the non-LoRA configs in configs/ do not carry them.
+    training_cfg = config["training"]
+    args.lora_r = int(training_cfg.get("lora_r", args.lora_r))
+    args.lora_alpha = int(training_cfg.get("lora_alpha", args.lora_alpha))
+    args.lora_dropout = float(training_cfg.get("lora_dropout", args.lora_dropout))
     args.batch_size = int(config["training"]["batch_size"])
     args.gradient_accumulation_steps = int(config["training"]["gradient_accumulation_steps"])
     args.warmup_steps = int(config["training"]["warmup_steps"])
@@ -289,10 +297,14 @@ def train(args: argparse.Namespace) -> None:
     )
     model.config.pad_token_id = tokenizer.pad_token_id
 
+    logger.info(
+        "LoRA config: r=%s alpha=%s dropout=%s",
+        args.lora_r, args.lora_alpha, args.lora_dropout,
+    )
     lora_config = LoraConfig(
-        r=8,
-        lora_alpha=8,
-        lora_dropout=0.05,
+        r=args.lora_r,
+        lora_alpha=args.lora_alpha,
+        lora_dropout=args.lora_dropout,
         target_modules=["q_proj", "k_proj", "v_proj", "dense"],
         bias="none",
         task_type=TaskType.CAUSAL_LM,
@@ -370,6 +382,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output_dir", type=str, default="./results")
     parser.add_argument("--logging_dir", type=str, default="./results/logs")
     parser.add_argument("--max_source_length", type=int, default=512)
+    # Used when the YAML config does not carry LoRA keys (the configs/ set does not).
+    # alpha defaults to 8 here, matching what this script previously hardcoded.
+    parser.add_argument("--lora_r", type=int, default=8)
+    parser.add_argument("--lora_alpha", type=int, default=8)
+    parser.add_argument("--lora_dropout", type=float, default=0.05)
     parser.add_argument("--max_target_length", type=int, default=128)
     parser.add_argument("--num_train_epochs", type=float, default=3.0)
     parser.add_argument("--learning_rate", type=float, default=2e-4)

--- a/summarization/imdb_code/train_shadow_model_llama3-1_lora.py
+++ b/summarization/imdb_code/train_shadow_model_llama3-1_lora.py
@@ -219,6 +219,14 @@ def apply_yaml_config(args: argparse.Namespace) -> argparse.Namespace:
     args.max_target_length = int(config["data"].get("max_target_length", 128))
     args.num_train_epochs = float(config["training"]["num_train_epochs"])
     args.learning_rate = float(config["training"]["learning_rate"])
+    # LoRA hyperparameters are three of the labels the attack classifier predicts, so
+    # they must come from the config -- hardcoding them made every config for this
+    # family train identically apart from learning rate. Fall back to the CLI defaults
+    # when the key is absent, since the non-LoRA configs in configs/ do not carry them.
+    training_cfg = config["training"]
+    args.lora_r = int(training_cfg.get("lora_r", args.lora_r))
+    args.lora_alpha = int(training_cfg.get("lora_alpha", args.lora_alpha))
+    args.lora_dropout = float(training_cfg.get("lora_dropout", args.lora_dropout))
     args.batch_size = int(config["training"]["batch_size"])
     args.gradient_accumulation_steps = int(config["training"]["gradient_accumulation_steps"])
     args.warmup_steps = int(config["training"]["warmup_steps"])
@@ -332,10 +340,14 @@ def train(args: argparse.Namespace) -> None:
             raise
     model.config.pad_token_id = tokenizer.pad_token_id
 
+    logger.info(
+        "LoRA config: r=%s alpha=%s dropout=%s",
+        args.lora_r, args.lora_alpha, args.lora_dropout,
+    )
     lora_config = LoraConfig(
-        r=8,
-        lora_alpha=16,
-        lora_dropout=0.05,
+        r=args.lora_r,
+        lora_alpha=args.lora_alpha,
+        lora_dropout=args.lora_dropout,
         target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
         bias="none",
         task_type=TaskType.CAUSAL_LM,
@@ -443,6 +455,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output_dir", type=str, default="./results")
     parser.add_argument("--logging_dir", type=str, default="./results/logs")
     parser.add_argument("--max_source_length", type=int, default=512)
+    # Used when the YAML config does not carry LoRA keys (the configs/ set does not).
+    parser.add_argument("--lora_r", type=int, default=8)
+    parser.add_argument("--lora_alpha", type=int, default=16)
+    parser.add_argument("--lora_dropout", type=float, default=0.05)
     parser.add_argument("--max_target_length", type=int, default=128)
     parser.add_argument("--num_train_epochs", type=float, default=3.0)
     parser.add_argument("--learning_rate", type=float, default=2e-4)

--- a/summarization/imdb_code/train_shadow_model_qwen2-5_lora.py
+++ b/summarization/imdb_code/train_shadow_model_qwen2-5_lora.py
@@ -219,6 +219,14 @@ def apply_yaml_config(args: argparse.Namespace) -> argparse.Namespace:
     args.max_target_length = int(config["data"].get("max_target_length", 128))
     args.num_train_epochs = float(config["training"]["num_train_epochs"])
     args.learning_rate = float(config["training"]["learning_rate"])
+    # LoRA hyperparameters are three of the labels the attack classifier predicts, so
+    # they must come from the config -- hardcoding them made every config for this
+    # family train identically apart from learning rate. Fall back to the CLI defaults
+    # when the key is absent, since the non-LoRA configs in configs/ do not carry them.
+    training_cfg = config["training"]
+    args.lora_r = int(training_cfg.get("lora_r", args.lora_r))
+    args.lora_alpha = int(training_cfg.get("lora_alpha", args.lora_alpha))
+    args.lora_dropout = float(training_cfg.get("lora_dropout", args.lora_dropout))
     args.batch_size = int(config["training"]["batch_size"])
     args.gradient_accumulation_steps = int(config["training"]["gradient_accumulation_steps"])
     args.warmup_steps = int(config["training"]["warmup_steps"])
@@ -334,10 +342,14 @@ def train(args: argparse.Namespace) -> None:
             raise
     model.config.pad_token_id = tokenizer.pad_token_id
 
+    logger.info(
+        "LoRA config: r=%s alpha=%s dropout=%s",
+        args.lora_r, args.lora_alpha, args.lora_dropout,
+    )
     lora_config = LoraConfig(
-        r=8,
-        lora_alpha=16,
-        lora_dropout=0.05,
+        r=args.lora_r,
+        lora_alpha=args.lora_alpha,
+        lora_dropout=args.lora_dropout,
         target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
         bias="none",
         task_type=TaskType.CAUSAL_LM,
@@ -445,6 +457,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output_dir", type=str, default="./results")
     parser.add_argument("--logging_dir", type=str, default="./results/logs")
     parser.add_argument("--max_source_length", type=int, default=512)
+    # Used when the YAML config does not carry LoRA keys (the configs/ set does not).
+    parser.add_argument("--lora_r", type=int, default=8)
+    parser.add_argument("--lora_alpha", type=int, default=16)
+    parser.add_argument("--lora_dropout", type=float, default=0.05)
     parser.add_argument("--max_target_length", type=int, default=128)
     parser.add_argument("--num_train_epochs", type=float, default=3.0)
     parser.add_argument("--learning_rate", type=float, default=2e-4)


### PR DESCRIPTION
Fixes two bugs in the decoder-only LoRA shadow-model scripts, found while porting the pipeline to a second task.

## 1. LoRA hyperparameters were never read from the config

`train_shadow_model_llama3-1_lora.py`, `train_shadow_model_qwen2-5_lora.py` and `simple_shadow_models_phi_lora.py` built `LoraConfig` from hardcoded values (`r=8`, `alpha=16`/`8`, `dropout=0.05`) and ignored `lora_r`, `lora_alpha` and `lora_dropout` in the YAML config.

Under the LoRA grid this means every config for those families trains identically apart from learning rate, so `lora_r`, `lora_alpha` and `lora_dropout` — three of the six prediction heads — would carry labels that had no effect on training. The BART trainer (`train_shadow_models_lora.py`) always read them correctly.

The values now come from the config, falling back to each script's previous hardcoded default when the key is absent. **The `configs/` set carries no `lora_*` columns, so those runs behave exactly as before** — this does not invalidate existing results from the main config set.

## 2. Train/inference prompt mismatch

The decoder-only trainers prompt with `Text: {text}\nSummary:` (newline) but the matching feature extractors used `Text: {text} Summary:` (space), so generation ran on a prompt the models were never trained on. The extractors now use the trainers' format.

**This one does change behavior:** any x1–x7 features already extracted for LLaMA, Qwen or Phi were produced under the mismatch and are stale relative to this code. Re-extraction would change (and likely improve) their features.

## Verification

All six files compile. All three trainers have consistent plumbing: three config reads with fallbacks, three CLI defaults, and `LoraConfig` wired to the resolved values. Trainer and extractor prompts now match on all three families.
